### PR TITLE
Sprint 1 basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,17 @@ docker-compose up --build
 
 A API ficará disponível em `http://localhost:8000`.
 
+Os principais endpoints de autenticação são:
+
+- `POST /register` – cria um novo usuário.
+- `POST /login` – retorna um token JWT.
+
+O endpoint raiz `/` exige um token válido no cabeçalho `Authorization` (formato `Bearer <token>`).
+
 ## Estrutura do Projeto
 
 - `backend/` - Código Python da API e dos workers.
-- `frontend/` - Código do frontend (a ser desenvolvido).
+- `frontend/` - Código do frontend com páginas de login e registro simples.
 - `docker-compose.yml` - Orquestração dos serviços em contêiner.
 - `Dockerfile` - Imagem base para API e workers.
 

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,67 @@
+from datetime import datetime, timedelta
+from jose import jwt
+from passlib.hash import argon2
+import os
+
+SECRET_KEY = os.getenv('SECRET_KEY', 'secret')
+ALGORITHM = 'HS256'
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+
+def get_password_hash(password: str) -> str:
+    return argon2.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    try:
+        return argon2.verify(plain_password, hashed_password)
+    except Exception:
+        return False
+
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None):
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+from jose import JWTError
+from fastapi import Depends, HTTPException
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.orm import Session
+
+from .database import SessionLocal
+from . import models
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def decode_token(token: str):
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        email: str = payload.get("sub")
+        if email is None:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        return email
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+
+def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)):
+    email = decode_token(token)
+    user = db.query(models.User).filter(models.User.email == email).first()
+    if user is None:
+        raise HTTPException(status_code=401, detail="User not found")
+    return user

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,25 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+import os
+
+DATABASE_URL = os.getenv('DATABASE_URL', 'sqlite:///./test.db')
+
+from sqlalchemy.pool import StaticPool
+
+connect_args = {}
+engine_options = {}
+if DATABASE_URL.startswith("sqlite"):
+    connect_args = {"check_same_thread": False}
+    if DATABASE_URL == "sqlite:///:memory:":
+        engine_options["poolclass"] = StaticPool
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args=connect_args,
+    **engine_options,
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,11 +1,11 @@
+import os
+
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-import os
-
-DATABASE_URL = os.getenv('DATABASE_URL', 'sqlite:///./test.db')
-
 from sqlalchemy.pool import StaticPool
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./test.db")
 
 connect_args = {}
 engine_options = {}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,13 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
 
+from . import routes, auth, models
 
 app = FastAPI()
 
 
 @app.get("/")
-def read_root():
-    return {"message": "Hello, RFPGen Pro"}
+def read_root(current_user: models.User = Depends(auth.get_current_user)):
+    return {"message": f"Hello, {current_user.username}"}
+
+
+app.include_router(routes.router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,21 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+class Role(Base):
+    __tablename__ = 'roles'
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True)
+    users = relationship('User', back_populates='role')
+
+class User(Base):
+    __tablename__ = 'users'
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True)
+    email = Column(String, unique=True, index=True)
+    hashed_password = Column(String)
+    role_id = Column(Integer, ForeignKey('roles.id'))
+    role = relationship('Role', back_populates='users')

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -3,12 +3,14 @@ from sqlalchemy.orm import relationship
 
 from .database import Base
 
+
 class Role(Base):
     __tablename__ = 'roles'
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, unique=True, index=True)
     users = relationship('User', back_populates='role')
+
 
 class User(Base):
     __tablename__ = 'users'

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,0 +1,57 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from datetime import timedelta
+
+from .database import SessionLocal, engine
+from . import models, schemas, auth
+
+models.Base.metadata.create_all(bind=engine)
+
+router = APIRouter()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post('/register', response_model=schemas.UserOut)
+def register(user: schemas.UserCreate, db: Session = Depends(get_db)):
+    if db.query(models.User).filter(models.User.email == user.email).first():
+        raise HTTPException(status_code=400, detail='Email already registered')
+    hashed_password = auth.get_password_hash(user.password)
+    db_role = None
+    if user.role_id:
+        db_role = db.query(models.Role).filter(models.Role.id == user.role_id).first()
+    if not db_role:
+        db_role = db.query(models.Role).filter(models.Role.name == 'user').first()
+        if not db_role:
+            db_role = models.Role(name='user')
+            db.add(db_role)
+            db.commit()
+            db.refresh(db_role)
+    db_user = models.User(
+        username=user.username,
+        email=user.email,
+        hashed_password=hashed_password,
+        role_id=db_role.id,
+    )
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+@router.post('/login', response_model=schemas.Token)
+def login(form: schemas.LoginData, db: Session = Depends(get_db)):
+    db_user = db.query(models.User).filter(models.User.email == form.email).first()
+    if not db_user or not auth.verify_password(form.password, db_user.hashed_password):
+        raise HTTPException(status_code=400, detail='Incorrect email or password')
+    access_token = auth.create_access_token(
+        data={"sub": db_user.email},
+        expires_delta=timedelta(minutes=auth.ACCESS_TOKEN_EXPIRE_MINUTES),
+    )
+    return {"access_token": access_token, "token_type": "bearer"}

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
 from datetime import timedelta
 
-from .database import SessionLocal, engine
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
 from . import models, schemas, auth
+from .database import SessionLocal, engine
 
 models.Base.metadata.create_all(bind=engine)
 
@@ -18,18 +19,30 @@ def get_db():
         db.close()
 
 
-@router.post('/register', response_model=schemas.UserOut)
+@router.post("/register", response_model=schemas.UserOut)
 def register(user: schemas.UserCreate, db: Session = Depends(get_db)):
-    if db.query(models.User).filter(models.User.email == user.email).first():
-        raise HTTPException(status_code=400, detail='Email already registered')
+    if (
+        db.query(models.User)
+        .filter(models.User.email == user.email)
+        .first()
+    ):
+        raise HTTPException(status_code=400, detail="Email already registered")
     hashed_password = auth.get_password_hash(user.password)
     db_role = None
     if user.role_id:
-        db_role = db.query(models.Role).filter(models.Role.id == user.role_id).first()
+        db_role = (
+            db.query(models.Role)
+            .filter(models.Role.id == user.role_id)
+            .first()
+        )
     if not db_role:
-        db_role = db.query(models.Role).filter(models.Role.name == 'user').first()
+        db_role = (
+            db.query(models.Role)
+            .filter(models.Role.name == "user")
+            .first()
+        )
         if not db_role:
-            db_role = models.Role(name='user')
+            db_role = models.Role(name="user")
             db.add(db_role)
             db.commit()
             db.refresh(db_role)
@@ -45,11 +58,20 @@ def register(user: schemas.UserCreate, db: Session = Depends(get_db)):
     return db_user
 
 
-@router.post('/login', response_model=schemas.Token)
+@router.post("/login", response_model=schemas.Token)
 def login(form: schemas.LoginData, db: Session = Depends(get_db)):
-    db_user = db.query(models.User).filter(models.User.email == form.email).first()
-    if not db_user or not auth.verify_password(form.password, db_user.hashed_password):
-        raise HTTPException(status_code=400, detail='Incorrect email or password')
+    db_user = (
+        db.query(models.User)
+        .filter(models.User.email == form.email)
+        .first()
+    )
+    if not db_user or not auth.verify_password(
+        form.password,
+        db_user.hashed_password,
+    ):
+        raise HTTPException(
+            status_code=400, detail="Incorrect email or password"
+        )
     access_token = auth.create_access_token(
         data={"sub": db_user.email},
         expires_delta=timedelta(minutes=auth.ACCESS_TOKEN_EXPIRE_MINUTES),

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,11 +1,13 @@
 from pydantic import BaseModel
 from typing import Optional
 
+
 class UserCreate(BaseModel):
     username: str
     email: str
     password: str
     role_id: Optional[int] = None
+
 
 class UserOut(BaseModel):
     id: int
@@ -16,9 +18,11 @@ class UserOut(BaseModel):
     class Config:
         orm_mode = True
 
+
 class Token(BaseModel):
     access_token: str
     token_type: str
+
 
 class LoginData(BaseModel):
     email: str

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class UserCreate(BaseModel):
+    username: str
+    email: str
+    password: str
+    role_id: Optional[int] = None
+
+class UserOut(BaseModel):
+    id: int
+    username: str
+    email: str
+    role_id: Optional[int]
+
+    class Config:
+        orm_mode = True
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+class LoginData(BaseModel):
+    email: str
+    password: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,7 @@ uvicorn[standard]
 celery
 redis
 psycopg2-binary
+SQLAlchemy
+python-jose[cryptography]
+passlib[argon2]
+httpx

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login</title>
+</head>
+<body>
+    <h1>Login</h1>
+    <form id="login-form">
+        <label>Email: <input type="email" id="email"></label><br>
+        <label>Password: <input type="password" id="password"></label><br>
+        <button type="submit">Login</button>
+    </form>
+    <pre id="result"></pre>
+    <script>
+        document.getElementById('login-form').addEventListener('submit', async function(e) {
+            e.preventDefault();
+            const res = await fetch('/login', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({email: document.getElementById('email').value, password: document.getElementById('password').value})
+            });
+            const data = await res.json();
+            document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+            if (data.access_token) {
+                localStorage.setItem('token', data.access_token);
+            }
+        });
+    </script>
+</body>
+</html>

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Register</title>
+</head>
+<body>
+    <h1>Register</h1>
+    <form id="register-form">
+        <label>Username: <input type="text" id="username"></label><br>
+        <label>Email: <input type="email" id="email"></label><br>
+        <label>Password: <input type="password" id="password"></label><br>
+        <button type="submit">Register</button>
+    </form>
+    <pre id="result"></pre>
+    <script>
+        document.getElementById('register-form').addEventListener('submit', async function(e) {
+            e.preventDefault();
+            const res = await fetch('/register', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({username: document.getElementById('username').value,
+                    email: document.getElementById('email').value,
+                    password: document.getElementById('password').value})
+            });
+            const data = await res.json();
+            document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+        });
+    </script>
+</body>
+</html>

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -11,10 +11,10 @@ Este diretório reúne as tarefas sugeridas para iniciar o desenvolvimento do MV
 
 ## Sprint 1 – Autenticação Básica
 
-- [ ] Implementar modelos `User` e `Role` usando FastAPI e SQLAlchemy.
-- [ ] Criar endpoints de registro e login com senhas armazenadas via Argon2.
-- [ ] Gerar e validar tokens JWT para autenticação.
-- [ ] No frontend, criar páginas de login e registro simples.
+- [x] Implementar modelos `User` e `Role` usando FastAPI e SQLAlchemy.
+- [x] Criar endpoints de registro e login com senhas armazenadas via Argon2.
+- [x] Gerar e validar tokens JWT para autenticação.
+- [x] No frontend, criar páginas de login e registro simples.
 
 ## Sprint 2 – CI/CD e Qualidade de Código
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from fastapi.testclient import TestClient
+from backend.app import main, database, models
+
+# reinitialize database
+models.Base.metadata.create_all(bind=database.engine)
+client = TestClient(main.app)
+
+def test_register_and_login():
+    response = client.post('/register', json={
+        'username': 'tester',
+        'email': 'tester@example.com',
+        'password': 'secret'
+    })
+    assert response.status_code == 200, response.text
+
+    response = client.post('/login', json={
+        'email': 'tester@example.com',
+        'password': 'secret'
+    })
+    assert response.status_code == 200
+    token = response.json()['access_token']
+
+    response = client.get('/', headers={'Authorization': f'Bearer {token}'})
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- implement User and Role models
- build registration and login endpoints with JWT tokens
- secure root endpoint with login requirement
- add simple login & register pages
- document new endpoints and frontend
- mark sprint 1 tasks as done
- use in-memory sqlite for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843534836848332b0f0c199728c87a4