### PR TITLE
Add default admin and modern UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Os principais endpoints de autenticação são:
 - `POST /register` – cria um novo usuário.
 - `POST /login` – retorna um token JWT.
 
+Durante a inicialização, um usuário **admin** é criado automaticamente com:
+
+- Usuário: `admin@example.com`
+- Senha: `admin`
+
 O endpoint raiz `/` exige um token válido no cabeçalho `Authorization` (formato `Bearer <token>`).
 
 ## Estrutura do Projeto

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -1,30 +1,63 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <title>Login</title>
+    <meta charset="UTF-8">
+    <title>RFPGen Pro - Login</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-xwQUK8T0aCl5fCdbEImdbiKLog50qD0e/UEM7sGPzO0b0v6Jl2aT90fPrmEu8x93+RaJgVhIaK3d3Na8P+JfSw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+        body {font-family: Arial, sans-serif; background-color:#f2f6fc; display:flex; justify-content:center; align-items:center; height:100vh; margin:0;}
+        .container{background:#fff; padding:2rem; border-radius:8px; box-shadow:0 2px 4px rgba(0,0,0,0.1); width:320px; animation:fade 0.6s ease-in-out;}
+        @keyframes fade{from{opacity:0; transform:translateY(-10px);} to{opacity:1; transform:none;}}
+        h1{margin-top:0; color:#1e3a8a; text-align:center;}
+        .input-group{margin-bottom:1rem;}
+        label{display:block; margin-bottom:0.5rem; color:#1e3a8a;}
+        input{width:100%; padding:0.5rem; border:1px solid #cbd5e1; border-radius:4px;}
+        button{width:100%; background-color:#2563eb; color:#fff; border:none; padding:0.75rem; border-radius:4px; cursor:pointer;}
+        button:hover{background-color:#1d4ed8;}
+        #error{color:red; margin-top:0.5rem; text-align:center;}
+        .logo{text-align:center; margin-bottom:1rem;}
+        .logo img{max-width:120px;}
+    </style>
 </head>
 <body>
-    <h1>Login</h1>
+<div class="container">
+    <div class="logo">
+        <img id="logo" src="" alt="Logo">
+    </div>
+    <h1><i class="fa fa-sign-in-alt"></i> Login</h1>
     <form id="login-form">
-        <label>Email: <input type="email" id="email"></label><br>
-        <label>Password: <input type="password" id="password"></label><br>
+        <div class="input-group">
+            <label for="email">Email</label>
+            <input type="email" id="email" required>
+        </div>
+        <div class="input-group">
+            <label for="password">Password</label>
+            <input type="password" id="password" required>
+        </div>
         <button type="submit">Login</button>
+        <div id="error"></div>
     </form>
-    <pre id="result"></pre>
-    <script>
-        document.getElementById('login-form').addEventListener('submit', async function(e) {
-            e.preventDefault();
-            const res = await fetch('/login', {
-                method: 'POST',
-                headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({email: document.getElementById('email').value, password: document.getElementById('password').value})
-            });
-            const data = await res.json();
-            document.getElementById('result').textContent = JSON.stringify(data, null, 2);
-            if (data.access_token) {
-                localStorage.setItem('token', data.access_token);
-            }
+</div>
+<script>
+    document.getElementById('login-form').addEventListener('submit', async function(e){
+        e.preventDefault();
+        const res = await fetch('/login', {
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body:JSON.stringify({
+                email:document.getElementById('email').value,
+                password:document.getElementById('password').value
+            })
         });
-    </script>
+        if(res.ok){
+            const data = await res.json();
+            localStorage.setItem('token', data.access_token);
+            document.getElementById('error').textContent = '';
+            alert('Login successful');
+        }else{
+            document.getElementById('error').textContent = 'Erro ao fazer login';
+        }
+    });
+</script>
 </body>
 </html>

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -1,30 +1,66 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <title>Register</title>
+    <meta charset="UTF-8">
+    <title>RFPGen Pro - Register</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-xwQUK8T0aCl5fCdbEImdbiKLog50qD0e/UEM7sGPzO0b0v6Jl2aT90fPrmEu8x93+RaJgVhIaK3d3Na8P+JfSw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+        body {font-family: Arial, sans-serif; background-color:#f2f6fc; display:flex; justify-content:center; align-items:center; height:100vh; margin:0;}
+        .container{background:#fff; padding:2rem; border-radius:8px; box-shadow:0 2px 4px rgba(0,0,0,0.1); width:320px; animation:fade 0.6s ease-in-out;}
+        @keyframes fade{from{opacity:0; transform:translateY(-10px);} to{opacity:1; transform:none;}}
+        h1{margin-top:0; color:#1e3a8a; text-align:center;}
+        .input-group{margin-bottom:1rem;}
+        label{display:block; margin-bottom:0.5rem; color:#1e3a8a;}
+        input{width:100%; padding:0.5rem; border:1px solid #cbd5e1; border-radius:4px;}
+        button{width:100%; background-color:#2563eb; color:#fff; border:none; padding:0.75rem; border-radius:4px; cursor:pointer;}
+        button:hover{background-color:#1d4ed8;}
+        #error{color:red; margin-top:0.5rem; text-align:center;}
+        .logo{text-align:center; margin-bottom:1rem;}
+        .logo img{max-width:120px;}
+    </style>
 </head>
 <body>
-    <h1>Register</h1>
+<div class="container">
+    <div class="logo">
+        <img id="logo" src="" alt="Logo">
+    </div>
+    <h1><i class="fa fa-user-plus"></i> Register</h1>
     <form id="register-form">
-        <label>Username: <input type="text" id="username"></label><br>
-        <label>Email: <input type="email" id="email"></label><br>
-        <label>Password: <input type="password" id="password"></label><br>
+        <div class="input-group">
+            <label for="username">Username</label>
+            <input type="text" id="username" required>
+        </div>
+        <div class="input-group">
+            <label for="email">Email</label>
+            <input type="email" id="email" required>
+        </div>
+        <div class="input-group">
+            <label for="password">Password</label>
+            <input type="password" id="password" required>
+        </div>
         <button type="submit">Register</button>
+        <div id="error"></div>
     </form>
-    <pre id="result"></pre>
-    <script>
-        document.getElementById('register-form').addEventListener('submit', async function(e) {
-            e.preventDefault();
-            const res = await fetch('/register', {
-                method: 'POST',
-                headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({username: document.getElementById('username').value,
-                    email: document.getElementById('email').value,
-                    password: document.getElementById('password').value})
-            });
-            const data = await res.json();
-            document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+</div>
+<script>
+    document.getElementById('register-form').addEventListener('submit', async function(e){
+        e.preventDefault();
+        const res = await fetch('/register', {
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body:JSON.stringify({
+                username:document.getElementById('username').value,
+                email:document.getElementById('email').value,
+                password:document.getElementById('password').value
+            })
         });
-    </script>
+        if(res.ok){
+            document.getElementById('error').textContent = '';
+            alert('Usuário registrado');
+        }else{
+            document.getElementById('error').textContent = 'Erro ao registrar usuário';
+        }
+    });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create an admin user automatically on startup
- redesign login and register pages with a blue corporate style
- document the default admin credentials

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c3c81d0448332b74d1b4efdc61b6d