### PR TITLE
Add CORS middleware and adjust frontend endpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,17 @@
 from fastapi import FastAPI, Depends
+from fastapi.middleware.cors import CORSMiddleware
 
 from . import routes, auth, models
 from .database import SessionLocal
 
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+    allow_credentials=True,
+)
 
 
 @app.on_event("startup")

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -41,7 +41,7 @@
 <script>
     document.getElementById('login-form').addEventListener('submit', async function(e){
         e.preventDefault();
-        const res = await fetch('/login', {
+        const res = await fetch('http://localhost:8000/login', {
             method:'POST',
             headers:{'Content-Type':'application/json'},
             body:JSON.stringify({

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -45,7 +45,7 @@
 <script>
     document.getElementById('register-form').addEventListener('submit', async function(e){
         e.preventDefault();
-        const res = await fetch('/register', {
+        const res = await fetch('http://localhost:8000/register', {
             method:'POST',
             headers:{'Content-Type':'application/json'},
             body:JSON.stringify({


### PR DESCRIPTION
## Summary
- point login and register pages to the API server
- enable CORS for the frontend domain
- verify login flow works

## Testing
- `pytest -q`
- `npm test --silent`
- `uvicorn backend.app.main:app --port 8000` and `curl http://localhost:8000/login`

------
https://chatgpt.com/codex/tasks/task_e_684c4483d81c8332b4a607adc865a83c