### PR TITLE
Add basic project management UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ frontend/node_modules
 *.db
 .idea
 .vscode
+uploaded_rfps/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ docker-compose up --build
 A API ficará disponível em `http://localhost:8000`.
 
 O frontend simples pode ser acessado em `http://localhost:3000`.
+Após fazer login, abra `project.html` para criar projetos, fazer upload de RFPs
+e iniciar a análise via Celery.
 
 Os principais endpoints de autenticação são:
 
@@ -32,7 +34,7 @@ O endpoint raiz `/` exige um token válido no cabeçalho `Authorization` (format
 ## Estrutura do Projeto
 
 - `backend/` - Código Python da API e dos workers.
-- `frontend/` - Código do frontend com páginas de login e registro simples.
+- `frontend/` - Código do frontend com páginas de login, registro e projetos.
 - `docker-compose.yml` - Orquestração dos serviços em contêiner.
 - `Dockerfile` - Imagem base para API e workers.
 

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -1,0 +1,10 @@
+from celery import Celery
+import os
+
+celery_app = Celery(
+    'rfpgen',
+    broker=os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0'),
+    backend=os.getenv('CELERY_RESULT_BACKEND', 'redis://localhost:6379/0'),
+)
+
+celery_app.conf.task_routes = {'backend.app.tasks.*': {'queue': 'default'}}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI, Depends
 from fastapi.middleware.cors import CORSMiddleware
 
+from .celery_app import celery_app
+
 from . import routes, auth, models
 from .database import SessionLocal
 
@@ -50,3 +52,6 @@ def read_root(current_user: models.User = Depends(auth.get_current_user)):
 
 
 app.include_router(routes.router)
+
+# expose celery for worker entry point
+celery = celery_app

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -21,3 +21,22 @@ class User(Base):
     hashed_password = Column(String)
     role_id = Column(Integer, ForeignKey("roles.id"))
     role = relationship("Role", back_populates="users")
+
+
+class Project(Base):
+    __tablename__ = "projects"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True)
+    owner_id = Column(Integer, ForeignKey("users.id"))
+    owner = relationship("User")
+    rfps = relationship("RFP", back_populates="project")
+
+
+class RFP(Base):
+    __tablename__ = "rfps"
+
+    id = Column(Integer, primary_key=True, index=True)
+    filename = Column(String)
+    project_id = Column(Integer, ForeignKey("projects.id"))
+    project = relationship("Project", back_populates="rfps")

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,9 +1,11 @@
 from datetime import timedelta
 
-from fastapi import APIRouter, Depends, HTTPException
+import os
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 from sqlalchemy.orm import Session
 
-from . import models, schemas, auth
+from . import models, schemas, auth, tasks
 from .database import SessionLocal, engine
 
 models.Base.metadata.create_all(bind=engine)
@@ -59,3 +61,54 @@ def login(form: schemas.LoginData, db: Session = Depends(get_db)):
         expires_delta=timedelta(minutes=auth.ACCESS_TOKEN_EXPIRE_MINUTES),
     )
     return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.post("/projects", response_model=schemas.ProjectOut)
+def create_project(
+    project: schemas.ProjectCreate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(auth.get_current_user),
+):
+    db_project = models.Project(name=project.name, owner_id=current_user.id)
+    db.add(db_project)
+    db.commit()
+    db.refresh(db_project)
+    return db_project
+
+
+@router.post("/projects/{project_id}/rfps", response_model=schemas.RFPOut)
+def upload_rfp(
+    project_id: int,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(auth.get_current_user),
+):
+    project = db.query(models.Project).filter(models.Project.id == project_id).first()
+    if not project or project.owner_id != current_user.id:
+        raise HTTPException(status_code=404, detail="Project not found")
+    upload_dir = os.path.join(os.getcwd(), "uploaded_rfps")
+    os.makedirs(upload_dir, exist_ok=True)
+    file_path = os.path.join(upload_dir, file.filename)
+    with open(file_path, "wb") as f:
+        f.write(file.file.read())
+    db_rfp = models.RFP(filename=file.filename, project_id=project.id)
+    db.add(db_rfp)
+    db.commit()
+    db.refresh(db_rfp)
+    return db_rfp
+
+
+@router.post("/projects/{project_id}/rfps/{rfp_id}/analyze")
+def analyze_rfp(
+    project_id: int,
+    rfp_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(auth.get_current_user),
+):
+    project = db.query(models.Project).filter(models.Project.id == project_id).first()
+    rfp = db.query(models.RFP).filter(models.RFP.id == rfp_id).first()
+    if not project or not rfp or rfp.project_id != project.id or project.owner_id != current_user.id:
+        raise HTTPException(status_code=404, detail="RFP not found")
+    file_path = os.path.join(os.getcwd(), "uploaded_rfps", rfp.filename)
+    task = tasks.analyze_rfp.delay(file_path)
+    return {"task_id": task.id}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -27,3 +27,23 @@ class Token(BaseModel):
 class LoginData(BaseModel):
     email: str
     password: str
+
+
+class ProjectCreate(BaseModel):
+    name: str
+
+
+class ProjectOut(BaseModel):
+    id: int
+    name: str
+
+    class Config:
+        orm_mode = True
+
+
+class RFPOut(BaseModel):
+    id: int
+    filename: str
+
+    class Config:
+        orm_mode = True

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -1,0 +1,25 @@
+import os
+from .celery_app import celery_app
+
+try:
+    import openai
+    openai.api_key = os.getenv('OPENAI_API_KEY')
+except Exception:  # if openai not installed or other errors
+    openai = None
+
+@celery_app.task
+def analyze_rfp(file_path: str) -> str:
+    """Analyze RFP document using OpenAI GPT. If no API key, return preview."""
+    with open(file_path, 'r', errors='ignore') as f:
+        content = f.read()
+    if openai and openai.api_key:
+        try:
+            resp = openai.ChatCompletion.create(
+                model='gpt-3.5-turbo',
+                messages=[{'role': 'user', 'content': f'Summarize:\n{content}'}],
+            )
+            return resp.choices[0].message['content']
+        except Exception as exc:
+            return f'error: {exc}'
+    # fallback if no OpenAI
+    return content[:100]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,5 @@ SQLAlchemy
 python-jose[cryptography]
 passlib[argon2]
 httpx
+openai
+python-multipart

--- a/frontend/__tests__/projects.test.js
+++ b/frontend/__tests__/projects.test.js
@@ -1,0 +1,5 @@
+const fs = require('fs');
+
+test('project page exists', () => {
+  expect(fs.existsSync('project.html')).toBe(true);
+});

--- a/frontend/project.html
+++ b/frontend/project.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>RFPGen Pro - Projetos</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-xwQUK8T0aCl5fCdbEImdbiKLog50qD0e/UEM7sGPzO0b0v6Jl2aT90fPrmEu8x93+RaJgVhIaK3d3Na8P+JfSw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        background-color: #f2f6fc;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding-top: 40px;
+      }
+      form {
+        background-color: #fff;
+        padding: 20px;
+        border-radius: 8px;
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        margin-bottom: 20px;
+      }
+      input[type="text"], input[type="file"] {
+        width: 300px;
+        padding: 10px;
+        margin: 5px 0 10px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+      }
+      button {
+        padding: 10px 20px;
+        background-color: #4caf50;
+        color: white;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+      }
+      #result {
+        margin-top: 10px;
+        color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Gerenciar Projetos</h1>
+    <div id="auth-warning" style="color:red;"></div>
+    <form id="project-form">
+      <label>Nome do Projeto</label><br />
+      <input type="text" id="project-name" required />
+      <button type="submit">Criar Projeto</button>
+    </form>
+
+    <form id="rfp-form" style="display:none;">
+      <label>Upload da RFP</label><br />
+      <input type="file" id="rfp-file" required />
+      <button type="submit">Enviar RFP</button>
+    </form>
+
+    <button id="analyze-btn" style="display:none;">Analisar RFP</button>
+    <div id="result"></div>
+
+    <script>
+      const token = localStorage.getItem('token');
+      if (!token) {
+        document.getElementById('auth-warning').textContent = 'Faça login primeiro.';
+      }
+      let projectId = null;
+      let rfpId = null;
+
+      document.getElementById('project-form').addEventListener('submit', async e => {
+        e.preventDefault();
+        const res = await fetch('http://localhost:8000/projects', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ name: document.getElementById('project-name').value }),
+        });
+        if (res.ok) {
+          const data = await res.json();
+          projectId = data.id;
+          document.getElementById('rfp-form').style.display = 'block';
+          document.getElementById('result').textContent = 'Projeto criado com ID ' + projectId;
+        } else {
+          document.getElementById('result').textContent = 'Erro ao criar projeto';
+        }
+      });
+
+      document.getElementById('rfp-form').addEventListener('submit', async e => {
+        e.preventDefault();
+        const fileInput = document.getElementById('rfp-file');
+        const formData = new FormData();
+        formData.append('file', fileInput.files[0]);
+        const res = await fetch(`http://localhost:8000/projects/${projectId}/rfps`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          body: formData,
+        });
+        if (res.ok) {
+          const data = await res.json();
+          rfpId = data.id;
+          document.getElementById('analyze-btn').style.display = 'block';
+          document.getElementById('result').textContent = 'RFP enviada com ID ' + rfpId;
+        } else {
+          document.getElementById('result').textContent = 'Erro ao enviar RFP';
+        }
+      });
+
+      document.getElementById('analyze-btn').addEventListener('click', async () => {
+        const res = await fetch(`http://localhost:8000/projects/${projectId}/rfps/${rfpId}/analyze`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          document.getElementById('result').textContent = 'Tarefa enviada: ' + data.task_id;
+        } else {
+          document.getElementById('result').textContent = 'Erro ao iniciar análise';
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -24,7 +24,18 @@ Este diretório reúne as tarefas sugeridas para iniciar o desenvolvimento do MV
 
 ## Sprint 3 – Próximos Passos
 
-- [ ] Desenvolver o módulo de Projetos e upload de RFPs.
-- [ ] Implementar tarefas Celery iniciais para análise de RFP usando GPT.
-- [ ] Planejar as funcionalidades da Sprint seguinte de acordo com o backlog.
+- [x] Desenvolver o módulo de Projetos e upload de RFPs.
+- [x] Implementar tarefas Celery iniciais para análise de RFP usando GPT.
+- [x] Planejar as funcionalidades da Sprint seguinte de acordo com o backlog.
+
+## Sprint 4 – Gerenciamento de Vendors e Assistants
+
+Planejada de acordo com `plano-inicial.md` para iniciar o fluxo de vendors e
+assistants.
+
+- [ ] CRUD de Fornecedores (Vendors).
+- [ ] CRUD de configurações de Assistants OpenAI (Admin).
+- [ ] Integração com a API da OpenAI para criar/atualizar Assistants.
+- [ ] Tarefa Celery para análise de aderência de vendors.
+- [ ] Início da geração da BoM assistida por IA.
 

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,0 +1,47 @@
+import os
+import sys
+temp_dir = os.path.abspath(os.path.dirname(__file__))
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["CELERY_TASK_ALWAYS_EAGER"] = "true"
+os.environ["CELERY_BROKER_URL"] = "memory://"
+os.environ["CELERY_RESULT_BACKEND"] = "cache+memory://"
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi.testclient import TestClient
+from backend.app import main, database, models
+
+models.Base.metadata.create_all(bind=database.engine)
+client = TestClient(main.app)
+
+
+def create_user_and_token():
+    client.post(
+        "/register",
+        json={"username": "projuser", "email": "proj@example.com", "password": "pw"},
+    )
+    resp = client.post("/login", json={"email": "proj@example.com", "password": "pw"})
+    return resp.json()["access_token"]
+
+
+def test_project_and_rfp_upload(tmp_path):
+    token = create_user_and_token()
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = client.post("/projects", json={"name": "My Project"}, headers=headers)
+    assert resp.status_code == 200
+    project_id = resp.json()["id"]
+
+    file_path = tmp_path / "rfp.txt"
+    file_path.write_text("hello rfp")
+    with open(file_path, "rb") as f:
+        resp = client.post(
+            f"/projects/{project_id}/rfps", files={"file": ("rfp.txt", f, "text/plain")}, headers=headers
+        )
+    assert resp.status_code == 200
+    rfp_id = resp.json()["id"]
+
+    resp = client.post(f"/projects/{project_id}/rfps/{rfp_id}/analyze", headers=headers)
+    assert resp.status_code == 200
+    assert "task_id" in resp.json()


### PR DESCRIPTION
## Summary
- add project.html with forms to create projects and upload RFPs
- store uploaded_rfps in gitignore
- document new page usage in README
- note upcoming sprint in tasks list
- include simple frontend test for project page

## Testing
- `npm test --prefix frontend --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c75288dd88332ae9ff935470577aa