### PR TITLE
Fix Celery Redis connection in Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Para iniciar os serviços de desenvolvimento (API, worker, banco de dados e Redi
 docker-compose up --build
 ```
 
+O arquivo `docker-compose.yml` já define as variáveis de ambiente
+`CELERY_BROKER_URL` e `CELERY_RESULT_BACKEND` apontando para o serviço
+`redis`, garantindo que os workers do Celery consigam se conectar ao
+Redis corretamente.
+
 A API ficará disponível em `http://localhost:8000`.
 
 O frontend simples pode ser acessado em `http://localhost:3000`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,9 @@ services:
       - ./backend:/app/backend
     ports:
       - "8000:8000"
+    environment:
+      CELERY_BROKER_URL: redis://redis:6379/0
+      CELERY_RESULT_BACKEND: redis://redis:6379/0
     depends_on:
       - db
       - redis
@@ -32,6 +35,9 @@ services:
     command: celery -A backend.app.main worker -l info
     volumes:
       - ./backend:/app/backend
+    environment:
+      CELERY_BROKER_URL: redis://redis:6379/0
+      CELERY_RESULT_BACKEND: redis://redis:6379/0
     depends_on:
       - db
       - redis


### PR DESCRIPTION
## Summary
- set `CELERY_BROKER_URL` and `CELERY_RESULT_BACKEND` in `api` and `worker`
- document Celery environment variables in README

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7dd9deec83328e27cceb3d889c34