### PR TITLE
Fix celery default redis host

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -1,10 +1,12 @@
 from celery import Celery
 import os
 
+default_redis = 'redis://redis:6379/0'
+
 celery_app = Celery(
     'rfpgen',
-    broker=os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0'),
-    backend=os.getenv('CELERY_RESULT_BACKEND', 'redis://localhost:6379/0'),
+    broker=os.getenv('CELERY_BROKER_URL', default_redis),
+    backend=os.getenv('CELERY_RESULT_BACKEND', default_redis),
 )
 
 celery_app.conf.task_routes = {'backend.app.tasks.*': {'queue': 'default'}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,8 @@ services:
 
   worker:
     build: .
-    command: celery -A backend.app.main worker -l info
+    # start worker with explicit celery app module to avoid FastAPI conflict
+    command: celery -A backend.app.celery_app:celery_app worker -l info
     volumes:
       - ./backend:/app/backend
     environment:


### PR DESCRIPTION
## Summary
- default Celery Redis connection to the `redis` hostname
- ensure the Celery worker uses the correct application

## Testing
- `pip install -q -r backend/requirements.txt`
- `pip install -q -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c8150d13483328d0e99785f3dc291